### PR TITLE
Optional redirect-gateway on client

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -338,7 +338,6 @@ tls-crypt tc.key
 topology subnet
 server 10.8.0.0 255.255.255.0
 ifconfig-pool-persist ipp.txt" > /etc/openvpn/server/server.conf
-	echo 'push "redirect-gateway def1 bypass-dhcp"' >> /etc/openvpn/server/server.conf
 	# DNS
 	case "$dns" in
 		1|"")
@@ -448,7 +447,8 @@ auth SHA512
 cipher AES-256-CBC
 ignore-unknown-option block-outside-dns
 block-outside-dns
-verb 3" > /etc/openvpn/server/client-common.txt
+verb 3
+redirect-gateway def1 bypass-dhcp" > /etc/openvpn/server/client-common.txt
 	# Enable and start the OpenVPN service
 	systemctl enable --now openvpn-server@server.service
 	# Generates the custom client.ovpn


### PR DESCRIPTION
# Motivation
Option `push "redirect-gateway def1 bypass-dhcp"` in server configuration does not allow client to disable routing of all traffic.
# Solution
Moved option `redirect-gateway def1 bypass-dhcp` from server configuration to client configuration. 
So client will be able to disable routing of all traffic by removing option from configuration.