### PR TITLE
Enable client-to-client option

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -378,6 +378,7 @@ persist-key
 persist-tun
 status openvpn-status.log
 verb 3
+client-to-client
 crl-verify crl.pem" >> /etc/openvpn/server/server.conf
 	if [[ "$protocol" = "udp" ]]; then
 		echo "explicit-exit-notify" >> /etc/openvpn/server/server.conf


### PR DESCRIPTION
# Motivation
By default, clients will only see the server, but don't see other clients.
# Solution
Added option `client-to-client` to server configuration. This option allows connectivity between any pair of clients.